### PR TITLE
fix!: make package ES5/CJS only

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "require": "./dist-cjs/index.js",
       "import": "./dist-esm/index.js"
+    },
+    "./schema": {
+      "require": "./dist-cjs/Schema/index.js",
+      "import": "./dist-esm/Schema/index.js"
     }
   },
   "main": "./dist-cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma-spectrum/reflector",
-  "version": "0.0.0-pr.9.1.a3a33b7",
+  "version": "0.0.0-pr.9.2.e2fdbb9",
   "repository": "git@github.com:prisma/reflector.git",
   "author": "Jason Kuhrt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma-spectrum/reflector",
-  "version": "0.0.0-pr.9.2.e2fdbb9",
+  "version": "0.0.0-pr.9.3.5cbd126",
   "repository": "git@github.com:prisma/reflector.git",
   "author": "Jason Kuhrt",
   "license": "MIT",
@@ -9,26 +9,6 @@
     "dist-cjs",
     "dist-esm"
   ],
-  "exports": {
-    ".": {
-      "require": "./dist-cjs/index.js",
-      "import": "./dist-esm/index.js"
-    },
-    "./schema": {
-      "require": "./dist-cjs/Schema/index.js",
-      "import": "./dist-esm/Schema/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "schema": [
-        "./dist-cjs/Schema/index.d.ts"
-      ],
-      "*": [
-        "./*"
-      ]
-    }
-  },
   "main": "./dist-cjs/index.js",
   "module": "./dist-esm/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma-spectrum/reflector",
-  "version": "0.0.0-pr.9.3.5cbd126",
+  "version": "0.0.0-dripip",
   "repository": "git@github.com:prisma/reflector.git",
   "author": "Jason Kuhrt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma-spectrum/reflector",
-  "version": "0.5.0",
+  "version": "0.0.0-pr.9.1.a3a33b7",
   "repository": "git@github.com:prisma/reflector.git",
   "author": "Jason Kuhrt",
   "license": "MIT",
@@ -17,6 +17,16 @@
     "./schema": {
       "require": "./dist-cjs/Schema/index.js",
       "import": "./dist-esm/Schema/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "schema": [
+        "./dist-cjs/Schema/index.d.ts"
+      ],
+      "*": [
+        "./*"
+      ]
     }
   },
   "main": "./dist-cjs/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     }
   },
   "compilerOptions": {
+    // Until Prisma PDP modernizes its nextjs/webpack versions
+    "target": "ES5",
     // Make the compiler stricter, catch more errors
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
BREAKING CHANGE:

Package is only CJS compatible now and emits ES5. ES5 should not be a breaking change but it is a kind of downgrade. The CJS only aspect will break users depending on the ESM support.

The reason for this change is that Prisma Data Platform is using an old version of nextjs (11) and webpack (4). The build on that project fails on libraries not using ES5 or using package exports field.