### PR TITLE
feat: Added mongodb support

### DIFF
--- a/src/Schema/datasource.ts
+++ b/src/Schema/datasource.ts
@@ -16,6 +16,7 @@ const datasourceProviderInput = {
   mysql: 'mysql',
   sqlserver: 'sqlserver',
   mongodb: 'mongodb',
+  'mongodb+srv': 'mongodb+srv',
   cockroachdb: 'cockroachdb',
 } as const
 
@@ -46,6 +47,7 @@ const datasourceProviderTypeInputNormalizedMapping: Record<
   mysql: 'mysql',
   sqlserver: 'sqlserver',
   mongodb: 'mongodb',
+  'mongodb+srv': 'mongodb',
   cockroachdb: 'cockroachdb',
 }
 


### PR DESCRIPTION
Both

`mongodb://root:randompassword@cluster0.ab1cd.mongodb.net/mydb`
`mongodb+srv://root:randompassword@cluster0.ab1cd.mongodb.net/mydb?retryWrites=true&w=majority`

Are considered valid MongoDB connection strings,

in the same manner that we cater for both `postgres` | 'postgresql'

This PR adds support for `mongodb+srv` as datasource input type which will still be noramlized to `mongodb`