### PR TITLE
fix!: client controller request bug

### DIFF
--- a/src/Client/controller.ts
+++ b/src/Client/controller.ts
@@ -104,7 +104,8 @@ export const getPrismaClient = async (params: {
 export const request = async (prisma: ClientBase, request: RequestInput): Promise<OperationOutput> => {
   try {
     await prisma.$connect()
-    return runRequest(prisma, request)
+    const result = await runRequest(prisma, request)
+    return result
   } finally {
     await prisma.$disconnect()
   }


### PR DESCRIPTION
Problem: the `request()` on the Client controller is not waiting for the result from the runRequest and so proceeds to the finally block before the runRequest finishes.

This PR addresses this by awaiting the runRequest result.

[Slack thread](https://prisma-company.slack.com/archives/C016KUHB1R6/p1656588313002569)